### PR TITLE
Prepare revision 2 of v0.26.1 to utilize new release APK publishing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
             archivesBaseName = "NewPipe_x_SponsorBlock"
             android.applicationVariants.all { variant ->
                 variant.outputs.all { output ->
-                    def forkRevision = 1
+                    def forkRevision = 2
                     outputFileName = "${archivesBaseName}_v${variant.versionName}-${forkRevision}.apk"
                 }
             }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Fork Revision (user facing)

#### Description of the changes in your PR
After merge, a smaller, more performant release APK of `v0.26.1` should get automatically published to the [Releases](https://github.com/javulticat/NewPipe/releases) page.  To avoid name clashing and/or confusion with the previous release, this release will get named `v0.26.1-2` (with the `2` signifying that it is the 2nd revision/release based on the same upstream version by this fork).

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #3 

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- #4 
