### PR TITLE
Enable CI for default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - dev
       - master
       - release**
+      - sponsorblock
     paths-ignore:
       - 'README.md'
       - 'doc/**'
@@ -19,6 +20,7 @@ on:
     branches:
       - dev
       - master
+      - sponsorblock
     paths-ignore:
       - 'README.md'
       - 'doc/**'


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
CI testing doesn't currently run on the `sponsorblock` branch (or PRs targeting the `sponsorblock` branch), which greatly reduces its usefulness in detecting potential bugs before merging PRs.  This PR should allow it to run now.