### PR TITLE
Update contact email so new maintainer receives any emailed error reports

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
@@ -63,7 +63,7 @@ public class ErrorActivity extends AppCompatActivity {
     // BUNDLE TAGS
     public static final String ERROR_INFO = "error_info";
 
-    public static final String ERROR_EMAIL_ADDRESS = "polymorphicshade@gmail.com";
+    public static final String ERROR_EMAIL_ADDRESS = "newpipe@javulticat.com";
     public static final String ERROR_EMAIL_SUBJECT = "Exception in ";
 
     public static final String ERROR_GITHUB_ISSUE_URL =


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Error reports from this fork were still set to get emailed to `polymorphicshade`'s personal email.  I set up a dedicated email address for this project (`newpipe@javulticat.com`) and have set it as the new address where error reports will now get emailed.