### PR TITLE
Update README and GitHub templates to be more relevant to fork

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,4 @@
-### Please do **not** open pull requests for *new features* now, as we are planning to rewrite large chunks of the code. Only bugfix PRs will be accepted. More details will be announced soon!
-
-NewPipe contribution guidelines
+Project Contribution Guidelines
 ===============================
 
 ## Crash reporting
@@ -11,7 +9,7 @@ You'll see *exactly* what is sent, be able to add **your comments**, and then se
 
 ## Issue reporting/feature requests
 
-* **Already reported**? Browse the [existing issues](https://github.com/TeamNewPipe/NewPipe/issues) to make sure your issue/feature hasn't been reported/requested.
+* **Already reported**? Browse the [existing issues](https://github.com/javulticat/NewPipe/issues) to make sure your issue/feature hasn't been reported/requested.
 * **Already fixed**? Check whether your issue/feature is already fixed/implemented.
 * **Still relevant**? Check if the issue still exists in the latest release/beta version.
 * **Can you fix it**? If you are an Android/Java developer, you are always welcome to fix an issue or implement a feature yourself. PRs welcome! See [Code contribution](#code-contribution) for more info.
@@ -22,15 +20,16 @@ You'll see *exactly* what is sent, be able to add **your comments**, and then se
 
 ## Translation
 
-* NewPipe is translated via [Weblate](https://hosted.weblate.org/projects/newpipe/strings/). Log in there with your GitHub account, or register.
+* `NewPipe` is translated via [Weblate](https://hosted.weblate.org/projects/newpipe/strings/). Log in there with your GitHub account, or register.
 * Add the language you want to translate if it is not there already: see [How to add a new language](https://github.com/TeamNewPipe/NewPipe/wiki/How-to-add-a-new-language-to-NewPipe) in the wiki.
-* NewPipe uses the [PrettyTime](https://github.com/ocpsoft/prettytime) library to display localized versions of dates and times. It needs to be translated, too. Read [these instructions to add a new language](https://www.ocpsoft.org/prettytime/#section-14) and [this issue](https://github.com/TeamNewPipe/NewPipe/issues/9134) for more info.
+* `NewPipe` uses the [PrettyTime](https://github.com/ocpsoft/prettytime) library to display localized versions of dates and times. It needs to be translated, too. Read [these instructions to add a new language](https://www.ocpsoft.org/prettytime/#section-14) and [this issue](https://github.com/TeamNewPipe/NewPipe/issues/9134) for more info.
+* This project uses the translations from upstream.
 
 ## Code contribution
 
 ### Guidelines
 
-* Stick to NewPipe's *style conventions* of [checkStyle](https://github.com/checkstyle/checkstyle) and [ktlint](https://github.com/pinterest/ktlint). They run each time you build the project.
+* Stick to the *style conventions* of [checkStyle](https://github.com/checkstyle/checkstyle) and [ktlint](https://github.com/pinterest/ktlint). They run each time you build the project.
 * Stick to [F-Droid contribution guidelines](https://f-droid.org/wiki/page/Inclusion_Policy).
 * In particular **do not bring non-free software** (e.g. binary blobs) into the project. Make sure you do not introduce any closed-source library from Google.
 
@@ -40,26 +39,21 @@ You'll see *exactly* what is sent, be able to add **your comments**, and then se
 * If there is no existing issue for what you want to work on, **open a new one**  describing the changes you are planning to introduce. This gives the team and the community a chance to give **feedback** before you spend time on something that is already in development, should be done differently, or should be avoided completely.
 * Please show **intention to maintain your features** and code after you contribute a PR. Unmaintained code is a hassle for core developers. If you do not intend to maintain features you plan to contribute, please rethink your submission, or clearly state that in the PR description.
 * Create PRs that cover only **one specific issue/solution/bug**. Do not create PRs that are huge monoliths and could have been split into multiple independent contributions.
-* NewPipe uses [NewPipeExtractor](https://github.com/TeamNewPipe/NewPipeExtractor) to fetch data from services. If you need to change something there, you must test your changes in NewPipe. Telling NewPipe to use your extractor version can be accomplished by editing the `app/build.gradle` file: the comments under the "NewPipe libraries" section of `dependencies` will help you out.
-
-### Kotlin in NewPipe
-* NewPipe will remain mostly Java for time being
-* Contributions containing a simple conversion from Java to Kotlin should be avoided. Conversions to Kotlin should only be done if Kotlin actually brings improvements like bug fixes or better performance which are not, or only with much more effort, implementable in Java. The core team sees Java as an easier to learn and generally well adopted programming language.
 
 ### Creating a Pull Request (PR)
 
-* Make changes on a **separate branch** with a meaningful name, not on the _master_ branch or the _dev_ branch. This is commonly known as *feature branch workflow*. You may then send your changes as a pull request (PR) on GitHub.
+* Make changes on a **separate branch** with a meaningful name, not on the `sponsorblock` branch or the `master` branch. This is commonly known as *feature branch workflow*. You may then send your changes as a pull request (PR) on GitHub.
 * Please **test** (compile and run) your code before submitting changes! Ideally, provide test feedback in the PR description. Untested code will **not** be merged!
 * Respond if someone requests changes or otherwise raises issues about your PRs.
 * Try to figure out yourself why builds on our CI fail.
-* Make sure your PR is **up-to-date** with the rest of the code. Often, a simple click on "Update branch" will do the job, but if not, you must *rebase* your branch on the `dev` branch manually and resolve the conflicts on your own. You can find help [on the wiki](https://github.com/TeamNewPipe/NewPipe/wiki/How-to-merge-a-PR). Doing this makes the maintainers' job way easier.
+* Make sure your PR is **up-to-date** with the rest of the code. Often, a simple click on "Update branch" will do the job, but if not, you must *rebase* your branch on the `sponsorblock` branch manually and resolve the conflicts on your own. You can find help [on the wiki](https://github.com/TeamNewPipe/NewPipe/wiki/How-to-merge-a-PR). Doing this makes the maintainers' job way easier.
 
 ## IDE setup & building the app
 
 ### Basic setup
 
-NewPipe is developed using [Android Studio](https://developer.android.com/studio/). Learn more about how to install it and how it works in the [official documentation](https://developer.android.com/studio/intro). In particular, make sure you have accepted Android Studio's SDK licences. Once Android Studio is ready, setting up the NewPipe project is fairly simple:
-- Clone the NewPipe repository with `git clone https://github.com/TeamNewPipe/NewPipe.git` (or use the link from your own fork, if you want to open a PR).
+Android apps are typically developed using [Android Studio](https://developer.android.com/studio/). Learn more about how to install it and how it works in the [official documentation](https://developer.android.com/studio/intro). In particular, make sure you have accepted Android Studio's SDK licences. Once Android Studio is ready, setting up the project is fairly simple:
+- Clone the repository with `git clone https://github.com/javulticat/NewPipe.git` (or use the link from your own fork, if you want to open a PR).
 - Open the folder you just cloned with Android Studio.
 - Build and run it just like you would do with any other app, with the green triangle in the top bar.
 
@@ -83,6 +77,7 @@ The [ktlint](https://github.com/pinterest/ktlint) plugin does the same job as ch
 
 ## Communication
 
-* The #newpipe channel on Libera Chat (`ircs://irc.libera.chat:6697/newpipe`) has the core team and other developers in it. [Click here for webchat](https://web.libera.chat/#newpipe)!
-* You can also use a Matrix account to join the NewPipe channel at [#newpipe:libera.chat](https://matrix.to/#/#newpipe:libera.chat). Some convenient clients, available both for phone and desktop, are listed at that link.
-* You can post your suggestions, changes, ideas etc. on either GitHub or IRC.
+* All communication is done through GitHub.
+* Create an [Issue](https://github.com/javulticat/NewPipe/issues/new/choose) if you have a bug report or feature request.
+* Start a [Discussion](https://github.com/javulticat/NewPipe/discussions/new/choose) if you have an idea, question, etc.
+* Share your thoughts (and/or emoji reactions) on existing [Issues](https://github.com/javulticat/NewPipe/issues) and [Discussions](https://github.com/javulticat/NewPipe/discussions).

--- a/.github/DISCUSSION_TEMPLATE/questions.yml
+++ b/.github/DISCUSSION_TEMPLATE/questions.yml
@@ -1,5 +1,5 @@
 name: Question
-description: Ask about anything NewPipe-related
+description: Ask a question about the project
 labels: [question]
 body:
   - type: markdown
@@ -7,26 +7,24 @@ body:
       value: |
         Thanks for taking the time to fill out this form! :hugs:
 
-        Note that you can also ask questions on our [IRC channel](https://web.libera.chat/#newpipe).
-
   - type: checkboxes
     id: checklist
     attributes:
       label: "Checklist"
       options:
-        - label: "I made sure that there are *no existing issues or discussions* - [open](https://github.com/TeamNewPipe/NewPipe/issues) or [closed](https://github.com/TeamNewPipe/NewPipe/issues?q=is%3Aissue+is%3Aclosed) - which I could contribute my information to."
+        - label: "I made sure that my question *has not* already been asked by searching the [existing questions](https://github.com/javulticat/NewPipe/discussions/categories/questions?discussions_q=)"
           required: true
-        - label: "I have read the [FAQ](https://newpipe.net/FAQ/) and my question isn't listed."
+        - label: "I have read the *entire* [README](https://github.com/javulticat/NewPipe#readme), and I am sure it does not answer my question."
           required: true
-        - label: "I have taken the time to fill in all the required details. I understand that the question will be dismissed otherwise."
+        - label: "I have taken the time to completely fill in the required details. I understand that my question may be dismissed otherwise."
           required: true
-        - label: "I have read and understood the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/dev/.github/CONTRIBUTING.md)."
+        - label: "I have read and understood the [contribution guidelines](https://github.com/javulticat/NewPipe/blob/sponsorblock/.github/CONTRIBUTING.md)."
           required: true
 
   - type: textarea
     id: what-is-the-question
     attributes:
-      label: What is/are your question(s)?
+      label: What is your question?
     validations:
       required: true
 

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
-liberapay: TeamNewPipe
-custom: 'https://newpipe.net/donate/'
+custom: "If you know someone who would want to know that this project exists, please let them know :)"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for helping to make NewPipe better by reporting a bug. :hugs:
+        Thank you for helping to make this fork of `NewPipe` better by reporting a bug. :hugs:
 
         Please fill in as much information as possible about your bug so that we don't have to play "information ping-pong" and can help you immediately.
 
@@ -14,26 +14,35 @@ body:
     attributes:
       label: "Checklist"
       options:
-        - label: "I am able to reproduce the bug with the latest version given here: [CLICK THIS LINK](https://github.com/javulticat/NewPipe/releases/latest)."
+        - label: "I am able to reproduce the bug with the latest Release of this fork: [CLICK THIS LINK](https://github.com/javulticat/NewPipe/releases/latest)."
           required: true
-        - label: "I am *not* able to reproduce the bug with the *same version* of [upstream NewPipe](https://github.com/TeamNewPipe/NewPipe/releases/)."
+        - label: "I am *not* able to reproduce the bug with the *same version* of [upstream `NewPipe`](https://github.com/TeamNewPipe/NewPipe/releases)."
           required: true
-        - label: "I made sure that there are *no existing issues* - [open](https://github.com/javulticat/NewPipe/issues) or [closed](https://github.com/javulticat/NewPipe/issues?q=is%3Aissue+is%3Aclosed) - which I could contribute my information to."
+        - label: "I made sure that there are *no existing bug reports* - [open](https://github.com/javulticat/NewPipe/issues?q=is%3Aissue+is%3Aopen+label%3Abug) or [closed](https://github.com/javulticat/NewPipe/issues?q=is%3Aissue+is%3Aclosed+label%3Abug) - which I could contribute my information to."
           required: true
-        - label: "I have read the [FAQ](https://newpipe.net/FAQ/) and my problem isn't listed."
+        - label: "I made sure that this bug is *not* [a known issue with upstream `NewPipe`](https://github.com/TeamNewPipe/NewPipe/issues?q=is%3Aissue+is%3Aopen+label%3Abug)."
           required: true
-        - label: "I have taken the time to fill in all the required details. I understand that the bug report will be dismissed otherwise."
+        - label: "I have taken the time to completely fill in the required details. I understand that my bug report may be dismissed otherwise."
           required: true
-        - label: "This issue contains only one bug."
+        - label: "I have limited the scope of this bug report to a single bug."
           required: true
         - label: "I have read and understood the [contribution guidelines](https://github.com/javulticat/NewPipe/blob/sponsorblock/.github/CONTRIBUTING.md)."
           required: true
 
   - type: input
+    id: fork-revision
+    attributes:
+     label: Affected release
+     description: "In which [Release](https://github.com/javulticat/NewPipe/releases) of this fork did you encounter the bug?"
+     placeholder: "x.xx.x-x - The version/tag of the Release on GitHub"
+    validations:
+      required: true
+
+  - type: input
     id: app-version
     attributes:
-     label: Affected version
-     description: "In which NewPipe version did you encounter the bug?"
+     label: App version
+     description: "What version number is shown in the app where you encountered the bug?"
      placeholder: "x.xx.x - Can be seen in the app from the 'About' section in the sidebar"
     validations:
       required: true
@@ -76,7 +85,7 @@ body:
 
         If applicable, add screenshots or a screen recording to help explain your problem.
         GitHub supports uploading them directly in the text box.
-        If your file is too big for Github to accept, try to compress it (ZIP-file) or feel free to paste a link to an image/video hoster here instead.
+        If your file is too big for GitHub to accept, try to compress it (ZIP-file) or feel free to paste a link to an image/video hoster here instead.
 
         :heavy_exclamation_mark: DON'T POST SCREENSHOTS OF THE ERROR PAGE.
         Instead, follow the instructions in the "Logs" section below.
@@ -114,4 +123,3 @@ body:
         * you have disabled all animations on your device
         * your cat disabled your network connection
         * ...
-

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: ❓ Question
-    url: https://github.com/TeamNewPipe/NewPipe/discussions/new?category=questions
-    about: Ask about anything NewPipe-related
-  - name: 💬 IRC
-    url: https://web.libera.chat/#newpipe
-    about: Chat with us via IRC for quick Q/A
-  - name: 💬 Matrix
-    url: https://matrix.to/#/#newpipe:libera.chat
-    about: Chat with us via Matrix for quick Q/A
+    url: https://github.com/javulticat/NewPipe/discussions/new?category=questions
+    about: Ask a question about the project

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for helping to make NewPipe better by suggesting a feature. :hugs:
+        Thank you for helping to make this fork of `NewPipe` better by suggesting a feature. :hugs:
 
         Your ideas are highly welcome! The app is made for you, the users, after all.
   - type: checkboxes
@@ -13,26 +13,27 @@ body:
     attributes:
       label: "Checklist"
       options:
-        - label: "I made sure that there are *no existing issues* - [open](https://github.com/javulticat/NewPipe/issues) or [closed](https://github.com/javulticat/NewPipe/issues?q=is%3Aissue+is%3Aclosed) - which I could contribute my information to."
+        - label: "I made sure that there are *no feature requests* - [open](https://github.com/javulticat/NewPipe/issues?q=is%3Aissue+is%3Aopen+label%3A%22feature+request%22) or [closed](https://github.com/javulticat/NewPipe/issues?q=is%3Aissue+is%3Aclosed+label%3A%22feature+request%22) - that already cover my request."
           required: true
-        - label: "I have read the [FAQ](https://newpipe.net/FAQ/) and my problem isn't listed."
+        - label: "My feature request has a well-defined scope and is described in sufficient detail."
           required: true
-        - label: "I'm aware that this is a request for NewPipe itself and that requests for adding a new service need to be made at [NewPipeExtractor](https://github.com/TeamNewPipe/NewPipeExtractor/issues)."
-          required: true
-        - label: "I have taken the time to fill in all the required details. I understand that the feature request will be dismissed otherwise."
-          required: true
-        - label: "This issue contains only one feature request."
+        - label: "I understand and accept that my feature request may not be considered unless it can attract significant community support."
           required: true
         - label: "I have read and understood the [contribution guidelines](https://github.com/javulticat/NewPipe/blob/sponsorblock/.github/CONTRIBUTING.md)."
           required: true
-
+        - label: "I am positive that my feature request meets *one* of the following criteria, and I have checked the *one* box that applies to my feature request below:"
+          required: true
+        - label: "My feature request relates to fork-specific functionality that does not exist upstream (e.g., `SponsorBlock`, `Return YouTube Dislike`)."
+          required: false
+        - label: "My feature request has already been opened upstream, _and_ it has been declined."
+          required: false
 
   - type: textarea
     id: feature-description
     attributes:
       label: Feature description
       description: |
-        Explain how you want the app's look or behavior to change to suit your needs.
+        Explain how you want the app's look or behavior to change.
     validations:
       required: true
 
@@ -48,9 +49,9 @@ body:
   - type: textarea
     id: why-relevant-to-fork
     attributes:
-      label: Why is the feature relevant to this fork?
+      label: Why is this feature relevant to this fork?
       description: |
-        Describe why your feature is relevant to the features this fork aims to provide over regular NewPipe or demonstrate that [upstream](https://github.com/TeamNewPipe/NewPipe/issues) is *explicitly* against implementing your feature for *non-technical reasons*.
+        Describe why this feature is relevant to this fork's specific functionality that does not exist upstream OR demonstrate that this feature has already been requested [upstream](https://github.com/TeamNewPipe/NewPipe/issues), and it was *explicitly* declined.
 
         (This is not the place for stale upstream feature requests!)
     validations:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->
+<!-- Hey there! Thank you so much for contributing to this project and filling out the following details. Having roughly the same layout helps everyone considerably :) -->
 
 #### What is it?
 - [ ] Bugfix (user facing)
@@ -7,17 +7,20 @@
 - [ ] Meta improvement to the project (dev facing)
 
 #### Description of the changes in your PR
-<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
+<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list. -->
 - record videos
 - create clones
 - take over the world
 
 #### Before/After Screenshots/Screen Record
-<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
+<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR. -->
 - Before:
 - After:
 
-#### Fixes the following issue(s)
+#### Fixes the following Issue(s)
+<!-- REQUIRED - Do not delete! -->
+<!-- All PRs MUST HAVE at least one associated Issue. -->
+<!-- PRs that do not link to an Issue may be closed. -->
 <!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
 - Fixes #
 
@@ -26,9 +29,9 @@
 - 
 
 #### APK testing
-<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
+<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "fix-comment-bug", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".) -->
 <!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
 The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).
 
 #### Due diligence
-- [ ] I read the [contribution guidelines](https://github.com/javulticat/NewPipe/blob/sponsorblock/.github/CONTRIBUTING.md).
+- [ ] I have read and understood the [contribution guidelines](https://github.com/javulticat/NewPipe/blob/sponsorblock/.github/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-## Fork Notice
-Please note that this is **a fork** of `polymorphicshade`'s popular [NewPipe fork](https://github.com/polymorphicshade/NewPipe) which originally integrated [SponsorBlock](https://sponsor.ajay.app/) and [Return YouTube Dislike](https://returnyoutubedislike.com/) functionality.
+### Fork Info
+Please note that this project is **a fork** of `polymorphicshade`'s popular [NewPipe fork](https://github.com/polymorphicshade/NewPipe) which originally integrated [SponsorBlock](https://sponsor.ajay.app/) and [Return YouTube Dislike](https://returnyoutubedislike.com/) functionality, which, unfortunately, was archived and is no longer maintained (as of December 29, 2023).
 
-This fork was created after learning that the original fork had its repository archived and will no longer be maintained (as of Dec 29, 2023).
+This project picks up from where the previous one left off. It is being actively maintained to ensure it is kept up-to-date with upstream `NewPipe` and fully incorporates the latest changes found in each new upstream release of `NewPipe`.
 
-This fork will primarily be maintained to pull in the latest features from upstream NewPipe if/when new versions of NewPipe are released. PRs for anything else are always welcome.
-
+Our app is designed to be a plug-and-play replacement for its discontinued parent. If there is any data you wish to migrate from your current app, [follow the guide here on how to export/import data](https://newpipe.net/FAQ/tutorials/import-export-data/#export-database).
+___
 # NewPipe x SponsorBlock x Return YouTube Dislike
-A fork of [NewPipe](https://github.com/TeamNewPipe/NewPipe) with [SponsorBlock](https://sponsor.ajay.app/) and [Return YouTube Dislike](https://returnyoutubedislike.com/) functionality.
-
 [![Release](https://img.shields.io/github/v/release/javulticat/NewPipe?label=Release)](https://github.com/javulticat/NewPipe/releases/latest)
 [![License](https://img.shields.io/github/license/javulticat/NewPipe?color=blue&label=License)](https://www.gnu.org/licenses/gpl-3.0)
 [![CI](https://github.com/javulticat/NewPipe/actions/workflows/ci.yml/badge.svg?branch=sponsorblock)](https://github.com/javulticat/NewPipe/actions?query=branch%3Asponsorblock)
+___
+A fork of [NewPipe](https://github.com/TeamNewPipe/NewPipe) with [SponsorBlock](https://sponsor.ajay.app/) and [Return YouTube Dislike](https://returnyoutubedislike.com/) functionality.
 
 ![01](.github/images/preview01.gif)
 ![02](.github/images/preview02.gif)
@@ -24,8 +24,24 @@ Currently, a couple of `polymorphicshade`'s original builds are still available 
 ### For versions after `v0.26.0`
 New builds will be uploaded in the [Releases](https://github.com/javulticat/NewPipe/releases) section. Please download the APK from the newest release and install it on your device.
 
+_F-Droid availability is [coming soon](https://github.com/users/javulticat/projects/2)._
+
 ## Why isn't this in upstream NewPipe?
 [The developer team](https://github.com/TeamNewPipe) behind the official NewPipe decided that they do not want to include these kinds of functionality in their app. See https://newpipe.schabi.org/blog/pinned/newpipe-and-online-advertising/, https://github.com/TeamNewPipe/NewPipe/pull/3205, and https://github.com/TeamNewPipe/NewPipe/issues/7469 for more information and discussion.
 
 ## Bugs
-Please do not report bugs encountered while using this fork to the upstream developers. Either try to reproduce the bug in vanilla NewPipe and then report it (preferred) or [create a bug report in our repo](https://github.com/javulticat/NewPipe/issues/new?assignees=&labels=bug&template=bug_report.md).
+
+If you encounter a bug while using this fork, please only [create a bug report in this repo](https://github.com/javulticat/NewPipe/issues/new?assignees=&labels=bug%2Cneeds+triage&projects=&template=bug_report.yml) after you have confirmed that:
+
+1. It is _not_ [a known issue with upstream `NewPipe`](https://github.com/TeamNewPipe/NewPipe/issues?q=is%3Aissue+is%3Aopen+label%3Abug).
+2. You are _not_ able to recreate the bug while using upstream `NewPipe`.
+   * If you find that you can, please report the bug to the upstream developers.
+
+## Feature Requests
+
+Please only [open a feature request in this repo](https://github.com/javulticat/NewPipe/issues/new?assignees=&labels=feature+request%2Cneeds+triage&projects=&template=feature_request.yml) if it meets one of the following criteria:
+
+* The feature request relates to fork-specific functionality that does not exist upstream (e.g., `SponsorBlock`, `Return YouTube Dislike`)
+* The feature request has already been opened upstream, _and_ it has been declined
+
+**Please note that changes to app functionality will not be made lightly.** Only feature requests that can attract significant community support are likely to be considered for acceptance.


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Updates the README to be more helpful/specific and updates many GitHub templates to make them more relevant and useful to this fork (many were unmodified from the upstream templates).

#### Fixes the following issue(s)
- Fixes #17 

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/javulticat/NewPipe/blob/sponsorblock/.github/CONTRIBUTING.md).
